### PR TITLE
Add Dependency on ActiveJob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,15 +2,15 @@ source 'https://rubygems.org/'
 
 ruby File.read('.ruby-version').match(/\d\.\d.\d/)[0]
 
-# application
+# Application:
 gem 'sinatra', '~> 1.4'
 gem 'puma', '>= 2.11.3'
 
-# rendering
+# Rendering:
 gem 'tilt-jbuilder', require: 'sinatra/jbuilder'
 gem 'multi_json'
 
-# persistence
+# Persistence:
 gem 'kaminari'
 # gem 'mongoid'
 # gem 'activerecord'
@@ -20,6 +20,11 @@ gem 'kaminari'
 # Exception and Performance Tracking:
 gem 'airbrake',     '>= 4.1.0'
 gem 'newrelic_rpm', '>= 3.11.2.286'
+
+# Asynchronous Processing:
+gem 'activejob', '>= 4.2.1'
+# gem 'sidekiq'
+# gem 'delayed_job'
 
 group :development do
   gem 'rake', '~> 10.0'

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'airbrake',     '>= 4.1.0'
 gem 'newrelic_rpm', '>= 3.11.2.286'
 
 # Asynchronous Processing:
-gem 'activejob', '>= 4.2.1'
+gem 'activejob', '>= 4.2.1', require: 'active_job'
 # gem 'sidekiq'
 # gem 'delayed_job'
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ end
 
 group :test do
   gem 'rspec', '>= 3.2.0'
+  gem 'rspec-activejob', '>= 0.4.1'
   gem 'rack-test', '~> 0.6'
   gem 'json_spec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,9 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.1)
+    activejob (4.2.1)
+      activesupport (= 4.2.1)
+      globalid (>= 0.3.0)
     activesupport (4.2.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -36,6 +39,8 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     ffi (1.9.8)
+    globalid (0.3.5)
+      activesupport (>= 4.1.0)
     i18n (0.7.0)
     iniparse (1.4.0)
     jbuilder (2.3.0)
@@ -124,6 +129,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activejob (>= 4.2.1)
   airbrake (>= 4.1.0)
   json_spec
   kaminari

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
       rspec-mocks (~> 3.3.0)
+    rspec-activejob (0.4.1)
+      activejob (>= 4.2)
+      rspec-mocks
     rspec-core (3.3.0)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.0)
@@ -141,6 +144,7 @@ DEPENDENCIES
   rack-test (~> 0.6)
   rake (~> 10.0)
   rspec (>= 3.2.0)
+  rspec-activejob (>= 0.4.1)
   rubocop (>= 0.31.0)
   sinatra (~> 1.4)
   tilt-jbuilder

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,0 +1,6 @@
+require 'active_job'
+
+# Configure ActiveJob to use the service's preferred backend (e.g.  `sidekiq`).
+#
+# `:inline` means: Process all jobs synchronously.
+ActiveJob::Base.queue_adapter = :inline

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,5 +1,3 @@
-require 'active_job'
-
 # Configure ActiveJob to use the service's preferred backend (e.g.  `sidekiq`).
 #
 # `:inline` means: Process all jobs synchronously.

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -1,0 +1,14 @@
+require 'active_job'
+require 'rspec/active_job'
+
+ActiveJob::Base.queue_adapter = :test
+ActiveJob::Base.logger = nil
+
+RSpec.configure do |config|
+  config.include(RSpec::ActiveJob)
+
+  config.after(:each) do
+    ActiveJob::Base.queue_adapter.enqueued_jobs = []
+    ActiveJob::Base.queue_adapter.performed_jobs = []
+  end
+end

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -1,4 +1,3 @@
-require 'active_job'
 require 'rspec/active_job'
 
 ActiveJob::Base.queue_adapter = :test


### PR DESCRIPTION
- add gem dependency on `activejob`
- add initializer to set the service's preferred backend
- add gem dependency on `rspec-activejob` for testing
- spec helper to configure `activejob` and `rspec-activejob` for testing
