### PR TITLE
Notify Airbrake about Exceptions in Sinatra

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem 'kaminari'
 # gem 'sequel'
 # gem 'pg'
 
+gem 'airbrake', '>= 4.1.0'
+
 group :development do
   gem 'rake', '~> 10.0'
   gem 'rubocop', '>= 0.31.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,9 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    airbrake (4.1.0)
+      builder
+      multi_json
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
@@ -120,6 +123,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (>= 4.1.0)
   json_spec
   kaminari
   multi_json

--- a/app/service.rb
+++ b/app/service.rb
@@ -3,6 +3,9 @@ require 'sinatra/base'
 
 # Add your documentation for the HTTP service here.
 class Service < Sinatra::Base
+  # Configure Sidekiq to notify Airbrake about exceptions...
+  configure { use Airbrake::Sinatra }
+
   ##
   # GET /ping
   #

--- a/app/service.rb
+++ b/app/service.rb
@@ -3,8 +3,8 @@ require 'sinatra/base'
 
 # Add your documentation for the HTTP service here.
 class Service < Sinatra::Base
-  # Configure Sidekiq to notify Airbrake about exceptions...
-  configure { use Airbrake::Sinatra }
+  # Configure Sinatra to notify Airbrake about exceptions...
+  use Airbrake::Sinatra
 
   ##
   # GET /ping

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,5 @@
+if ENV['AIRBRAKE_API_KEY'].present?
+  Airbrake.configure do |config|
+    config.api_key = ENV['AIRBRAKE_API_KEY']
+  end
+end

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,4 +1,4 @@
-if ENV['AIRBRAKE_API_KEY'].present?
+if ENV.key?('AIRBRAKE_API_KEY')
   Airbrake.configure do |config|
     config.api_key = ENV['AIRBRAKE_API_KEY']
   end


### PR DESCRIPTION
This initializes Airbrake based on the environment variable `AIRBRAKE_API_KEY` and configures Sinatra to use the middleware `Airbrake::Sinatra`. `AIRBRAKE_API_KEY` is the default name of the env variable Heroku sets if you add the their Airbrake plugin.