### PR TITLE
Respond with empty JSON on missing resource

### DIFF
--- a/app/service.rb
+++ b/app/service.rb
@@ -93,4 +93,9 @@ class Service < Sinatra::Base
 
     jbuilder :show
   end
+
+  not_found do
+    content_type 'application/json'
+    [404, '{}']
+  end
 end


### PR DESCRIPTION
Respond with empty JSON on missing resource instead default Sinatra html page
